### PR TITLE
fix: prevent horizontal scrollbar from lock tooltip layout shift

### DIFF
--- a/src/features/shell/AppShell.tsx
+++ b/src/features/shell/AppShell.tsx
@@ -77,7 +77,7 @@ export function AppShell({
 
       <main
         className={cn(
-          "flex-1 pr-6 flex transition-colors duration-300 lg:ml-20",
+          "flex-1 pr-6 flex transition-colors duration-300 lg:ml-20 overflow-x-hidden",
           bottomBar ? "pb-32 md:pb-24" : "pb-24 md:pb-16",
           !showTopbar && "pt-10 md:pt-5",
           bodyBg,


### PR DESCRIPTION
Add overflow-x-hidden to AppShell <main> element to clip any horizontal overflow caused by the tooltip's initial render position before useLayoutEffect corrects it.